### PR TITLE
Add support for using terminals that don't exist at the start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ your code, sorry, I kind of butchered it.
 ## Usage
 
 ```sh
-nbtty <command> [args...]
+nbtty [--tty <tty path>] <command> [args...]
 ```
+
+If you specify `--tty`, `nbtty` will use that tty instead of stdin/stdout. It
+will additionally retry opening the tty if it doesn't exist on start. This is
+useful for getting around the problem where Elixir code initializes a tty that's
+provides the main console.
 
 ## Building
 

--- a/main.c
+++ b/main.c
@@ -23,27 +23,17 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <syslog.h>
 #include <termios.h>
 #include <unistd.h>
 
 /* Make sure the binary has a copyright. */
 const char copyright[] = "nbtty - version 0.3.0 (C)Copyright 2004-2016 Ned T. Crigler, 2017 Frank Hunleth";
 
-/*
-** The original terminal settings. Shared between the master and attach
-** processes. The master uses it to initialize the pty, and the attacher uses
-** it to restore the original settings.
-*/
-struct termios orig_term;
-
 int main(int argc, char **argv)
 {
     if (argc < 2)
         errx(EXIT_FAILURE, "%s [--tty <path>] <command> [args...]", argv[0]);
-
-    /* Save the original terminal settings. */
-    if (tcgetattr(STDIN_FILENO, &orig_term) < 0)
-        errx(EXIT_FAILURE, "Attaching to a session requires a terminal.");
 
     int sv[2];
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0)

--- a/master.c
+++ b/master.c
@@ -249,7 +249,7 @@ static void master_process(char **argv)
 
         /* Wait for something to happen. */
         if (select(highest_fd + 1, &readfds, NULL, NULL, NULL) < 0) {
-            if (errno == EINTR || errno == EAGAIN)
+            if (errno == EINTR)
                 continue;
             exit(EXIT_FAILURE);
         }

--- a/master.c
+++ b/master.c
@@ -91,7 +91,7 @@ static int init_pty(char **argv)
     memset(&the_pty.ws, 0, sizeof(struct winsize));
 
     /* Create the pty process */
-    the_pty.pid = forkpty(&the_pty.fd, NULL, &orig_term, NULL);
+    the_pty.pid = forkpty(&the_pty.fd, NULL, NULL, NULL);
     if (the_pty.pid < 0)
         return -1;
     else if (the_pty.pid == 0) {

--- a/nbtty.h
+++ b/nbtty.h
@@ -21,8 +21,6 @@
 
 #include <config.h>
 
-extern struct termios orig_term;
-
 /*
 ** The master sends a simple stream of text to the attaching clients, without
 ** any protocol. This might change back to the packet based protocol in the

--- a/nbtty.h
+++ b/nbtty.h
@@ -35,7 +35,7 @@ extern struct termios orig_term;
 /* This hopefully moves to the bottom of the screen */
 #define EOS "\033[999H"
 
-int attach_main(int s);
+int attach_main(int s, const char *ttypath);
 int master_main(char **argv, int s);
 
 #endif


### PR DESCRIPTION
This should let `nbtty` support the use of configfs to set up the gadget serial port. See the second commit for details. I suspect that the final commit to not require a terminal will be useful if it's ever possible to specify no console for `erlinit`. I made that refactoring since it was weird for the terminal settings to be taken from stdin if you weren't going to use it.