### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ nbtty [--tty <tty path>] <command> [args...]
 
 If you specify `--tty`, `nbtty` will use that tty instead of stdin/stdout. It
 will additionally retry opening the tty if it doesn't exist on start. This is
-useful for getting around the problem where Elixir code initializes a tty that's
+useful for getting around the problem where Elixir code initializes a tty that
 provides the main console.
 
 ## Building


### PR DESCRIPTION
Thanks for adding this feature! I was just taking a look at the docs and noticed that there was a small typo.